### PR TITLE
feat(sw): adding support for sw-update

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -55,7 +55,75 @@
       gtag("js", new Date());
       gtag("config", "%REACT_APP_GOOGLE_ANALYTICS_TRACKING_ID%");
     </script>
+<style>
+    .snackbarPWA {
+      visibility: hidden;
+      width: 100%;
+      background-color: #333;
+      color: #fff;
+      text-align: center;
+      border-radius: 2px;
+      padding: 16px;
+      position: fixed;
+      z-index: 1;
+      bottom: 0px;
+      font-size: 17px;
+    }
 
+    #snackbarPWA.show {
+      visibility: visible;
+      -webkit-animation: fadein 0.5s;
+      animation: fadein 0.5s;
+    }
+
+    @-webkit-keyframes fadein {
+      from {
+        bottom: 0;
+        opacity: 0;
+      }
+
+      to {
+        bottom: 30px;
+        opacity: 1;
+      }
+    }
+
+    @keyframes fadein {
+      from {
+        bottom: 0;
+        opacity: 0;
+      }
+
+      to {
+        bottom: 30px;
+        opacity: 1;
+      }
+    }
+
+    @-webkit-keyframes fadeout {
+      from {
+        bottom: 30px;
+        opacity: 1;
+      }
+
+      to {
+        bottom: 0;
+        opacity: 0;
+      }
+    }
+
+    @keyframes fadeout {
+      from {
+        bottom: 30px;
+        opacity: 1;
+      }
+
+      to {
+        bottom: 0;
+        opacity: 0;
+      }
+    }
+  </style>
     <title>LunchWatch</title>
   </head>
   <body>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,4 +7,11 @@ import App from "./components/App/App";
 
 ReactDOM.render(<App />, document.getElementById("root"));
 
-serviceWorker.register();
+serviceWorker.register({ onUpdate: (swRegistration: ServiceWorkerRegistration, sw: ServiceWorker ) =>{
+    const snackbar = document.getElementById("snackbarPWA")
+      snackbar!.className = "show";
+      snackbar!.addEventListener('click', () => {
+        sw.postMessage({ action: 'skipWaiting' });
+        window.location.reload();
+      });
+}});

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,7 +8,7 @@ import App from "./components/App/App";
 ReactDOM.render(<App />, document.getElementById("root"));
 
 serviceWorker.register({ onUpdate: (swRegistration: ServiceWorkerRegistration, sw: ServiceWorker ) =>{
-    const snackbar = document.getElementById("snackbarPWA")
+    const snackbar = document.getElementById("#snackbarPWA")
       snackbar!.className = "show";
       snackbar!.addEventListener('click', () => {
         sw.postMessage({ action: 'skipWaiting' });

--- a/src/serviceWorker.ts
+++ b/src/serviceWorker.ts
@@ -22,7 +22,7 @@ const isLocalhost = Boolean(
 
 type Config = {
   onSuccess?: (registration: ServiceWorkerRegistration) => void;
-  onUpdate?: (registration: ServiceWorkerRegistration) => void;
+  onUpdate?: (registration: ServiceWorkerRegistration, serviceWorker: ServiceWorker) => void;
 };
 
 export function register(config?: Config) {
@@ -84,7 +84,7 @@ function registerValidSW(swUrl: string, config?: Config) {
 
               // Execute callback
               if (config && config.onUpdate) {
-                config.onUpdate(registration);
+                config.onUpdate(registration, installingWorker);
               }
             } else {
               // At this point, everything has been precached.


### PR DESCRIPTION
This PR includes small changes in the way that `react-app` handle the SW.
1. I added a `snackbar` element that has` visibility: none` until detecting a new `serviceWorker`  is detected 
Note: The class `show is added to set the `visibility: visible``)_.  </small>
2. On the `serviceWorker.ts` I added an extra param to the `onUpdate` callback, to be able to send a message to the `service worker`.
3.  On the `index.tsx`, I added the `onUpdate` callback to handle the notification and when you clicked to send a message to the worker to perform the update action.

Just have one missing step, configure the `service-worker.js` generated by react-app.
I made a little research and found that you need to `eject` the problem to handle this limitation.
[Limitations of default PWAs in CRA](https://www.freecodecamp.org/news/how-to-build-a-pwa-with-create-react-app-and-custom-service-workers-376bd1fdc6d3/)

I don't like the idea of `eject` the project for many reasons ( You need to tackle all the issues regarding custom `configuration`).

I've been working with PWA for almost 2 years, I highly recommend that instead of using the CRA Package for PWA's, use [Workbox](https://developers.google.com/web/tools/workbox/) the facto to manage service workers for all kind of javascript apps. They offer a lot of great customization without ejecting the project and the only change that is needed is included as a dependency and running the command on the `build` pipeline.

By the way, the missing step is: Listen to the message and `skipWaiting` to update all the clients(tabs) open :
![image](https://user-images.githubusercontent.com/17608169/66709148-172d6500-ed23-11e9-8e64-be5c4f54429d.png)
![image](https://user-images.githubusercontent.com/17608169/66709152-290f0800-ed23-11e9-8ddd-4d40b435eeb0.png)

```js
// service-worker.js
self.addEventListener('message', function(event) {
  if (event.data.action === 'skipWaiting') {
    self.skipWaiting();
  }
});
```
